### PR TITLE
Permit TaskStatusTable having no items with null selection

### DIFF
--- a/test/+wt/+test/TaskStatusTable.m
+++ b/test/+wt/+test/TaskStatusTable.m
@@ -121,7 +121,22 @@ classdef TaskStatusTable < wt.test.BaseWidgetTest
             % Verify selection color of selected label
             actValue = testCase.Widget.Label(newIdx).BackgroundColor;
             testCase.verifyEqual(actValue, selColor)
-            
+
+            % Now, programmatically change the index to empty
+            newIdx = [];
+            testCase.verifySetProperty("SelectedIndex", newIdx);
+            testCase.verifyEqual(testCase.Widget.SelectedIndex, newIdx)
+
+            % Can't press back
+            testCase.verifyFalse(backButton.Enable)
+            testCase.press(backButton)
+            testCase.verifyEqual(testCase.Widget.SelectedIndex, newIdx)
+
+            % Push forward
+            testCase.verifyTrue(fwdButton.Enable)
+            testCase.press(fwdButton)
+            testCase.verifyEqual(testCase.Widget.SelectedIndex, 1)
+
         end %function
             
         

--- a/widgets/+wt/TaskStatusTable.m
+++ b/widgets/+wt/TaskStatusTable.m
@@ -224,11 +224,13 @@ classdef TaskStatusTable < matlab.ui.componentcontainer.ComponentContainer & ...
             
             % Update selected task
             selLabel = obj.Label(obj.SelectedIndex);
-            nonSelLabel = obj.Label(obj.Label ~= selLabel);
-            wt.utility.fastSet(nonSelLabel,"BackgroundColor",'none');
             if ~isempty(selLabel)
+                nonSelLabel = obj.Label(obj.Label ~= selLabel);
                 wt.utility.fastSet(selLabel,"BackgroundColor",obj.SelectionColor);
+            else
+                nonSelLabel = obj.Label;
             end
+            wt.utility.fastSet(nonSelLabel,"BackgroundColor",'none');
             
             % Update the button enables
             obj.updateEnableableComponents();
@@ -251,8 +253,8 @@ classdef TaskStatusTable < matlab.ui.componentcontainer.ComponentContainer & ...
             obj.updateEnableableComponents@wt.mixin.Enableable();
             
             % Can we go forward or back, based on selected task?
-            canGoBack = obj.SelectedIndex > 1;
-            canGoForward = obj.SelectedIndex < numel(obj.Items);
+            canGoBack = ~isempty(obj.SelectedIndex) && obj.SelectedIndex > 1;
+            canGoForward = isempty(obj.SelectedIndex) || obj.SelectedIndex < numel(obj.Items);
             backEnable = obj.Enable && obj.EnableBack && canGoBack;
             forwardEnable = obj.Enable && obj.EnableForward && canGoForward;
             


### PR DESCRIPTION
These changes fix issue #54 and add testcases associated to the issue. 

I ran the complete test suite with the additional testcases on MATLAB R2022b. All seems fine.