### PR TITLE
Event data object reused in wt.ListSelectorTwoPane

### DIFF
--- a/test/+wt/+test/ListSelectorTwoPane.m
+++ b/test/+wt/+test/ListSelectorTwoPane.m
@@ -317,16 +317,16 @@ classdef ListSelectorTwoPane < wt.test.BaseWidgetTest
             w.UserButtons.Icon = ["plot_24.png","play_24.png"];
             drawnow            
             
-            % Press the buttons
+            % Add user buttons
             b = w.UserButtons.Button;
             testCase.verifyNumElements(b, 2);
             
-            %RAJ - not working
-            %testCase.press(b(1))
-            %testCase.press(b(2))
+            % Press user buttons
+            testCase.press(b(1))
+            testCase.press(b(2))
             
             % Verify callbacks fired
-            %testCase.verifyEqual(testCase.CallbackCount, 2);
+            testCase.verifyEqual(testCase.CallbackCount, 2);
             
         end %function
         

--- a/widgets/+wt/ListSelectorTwoPane.m
+++ b/widgets/+wt/ListSelectorTwoPane.m
@@ -301,7 +301,8 @@ classdef ListSelectorTwoPane < matlab.ui.componentcontainer.ComponentContainer &
 
                 otherwise
                     % Trigger event for user buttons
-                    notify(obj,"ButtonPushed",evt);
+                    evtOut = wt.eventdata.ButtonPushedData(evt.Button);
+                    notify(obj,"ButtonPushed",evtOut);
 
             end %switch
 


### PR DESCRIPTION
These changes fix issue #55 and also enable the testcases that were not working before because of this issue.

I ran the test suite with these changes in MATLAB R2022b. All seems fine.