### PR TITLE
Allow for deselection of HighlightedValue. Fixes in BaseApp.

### DIFF
--- a/widgets/+wt/+apps/BaseApp.m
+++ b/widgets/+wt/+apps/BaseApp.m
@@ -93,8 +93,21 @@ classdef BaseApp < matlab.apps.AppBase & matlab.mixin.SetGetExactNames & ...
     %% Constructor / destructor
     methods (Access = public)
         
-        function app = BaseApp(varargin)
+        function app = BaseApp(options)
+
             % Constructor
+
+            arguments
+                options.?wt.apps.BaseApp
+                options.Preferences (1,1) wt.model.Preferences = wt.model.Preferences;
+                options.PreferenceGroup (1,1) string = "";
+            end
+
+            % Check for preference input and assign it first, in case
+            % Preferences was subclassed
+            app.Preferences = options.Preferences;
+            app.PreferenceGroup = options.PreferenceGroup;
+            options = rmfield(options, ["Preferences" "PreferenceGroup"]);
             
             % Create the figure and hide until components are created
             app.Figure = uifigure( ...
@@ -132,8 +145,9 @@ classdef BaseApp < matlab.apps.AppBase & matlab.mixin.SetGetExactNames & ...
             app.setup();
             
             % Set any P-V pairs
-            if ~isempty(varargin)
-                set(app, varargin{:});
+            cellArgs = namedargs2cell(options);
+            if ~isempty(cellArgs)
+                set(app, cellArgs{:});
             end
             
             % Register the app with App Designer
@@ -155,7 +169,11 @@ classdef BaseApp < matlab.apps.AppBase & matlab.mixin.SetGetExactNames & ...
             drawnow
             
             % Now, make it visible
-            app.Figure.Visible = 'on';
+            if isfield(options, 'Visible')
+                app.Figure.Visible = options.Visible;
+            else
+                app.Figure.Visible = 'on';
+            end
             
         end %function
         

--- a/widgets/+wt/+apps/BaseApp.m
+++ b/widgets/+wt/+apps/BaseApp.m
@@ -179,6 +179,12 @@ classdef BaseApp < matlab.apps.AppBase & matlab.mixin.SetGetExactNames & ...
             % Destructor
             
             % Store last position in preferences
+
+            % Note: Use isprop instead of isvalid. 
+            % If a user deletes the figure instead of the app, 
+            % this delete method is still triggered. Although
+            % not yet fully deleted (prop values still available), 
+            % the app and figure are not valid at this point. 
             if isscalar(app.Figure) && isprop(app.Figure, "Position")
                 app.setPreference('Position',app.Figure.Position)
             end

--- a/widgets/+wt/+apps/BaseApp.m
+++ b/widgets/+wt/+apps/BaseApp.m
@@ -425,7 +425,7 @@ classdef BaseApp < matlab.apps.AppBase & matlab.mixin.SetGetExactNames & ...
         
         function value = get.PreferenceGroup(app)
             value = app.PreferenceGroup;
-            if isempty(value)
+            if ~strlength(value)
                 value = class(app);
             end
             value = matlab.lang.makeValidName(value);

--- a/widgets/+wt/+apps/BaseApp.m
+++ b/widgets/+wt/+apps/BaseApp.m
@@ -164,7 +164,7 @@ classdef BaseApp < matlab.apps.AppBase & matlab.mixin.SetGetExactNames & ...
             % Destructor
             
             % Store last position in preferences
-            if isscalar(app.Figure) && isvalid(app.Figure)
+            if isscalar(app.Figure) && isprop(app.Figure, "Position")
                 app.setPreference('Position',app.Figure.Position)
             end
             

--- a/widgets/+wt/+apps/BaseApp.m
+++ b/widgets/+wt/+apps/BaseApp.m
@@ -165,9 +165,6 @@ classdef BaseApp < matlab.apps.AppBase & matlab.mixin.SetGetExactNames & ...
             % Update the title
             app.updateTitle();
             
-            % Force drawing to finish
-            drawnow
-            
             % Now, make it visible
             if isfield(options, 'Visible')
                 app.Figure.Visible = options.Visible;

--- a/widgets/+wt/ListSelector.m
+++ b/widgets/+wt/ListSelector.m
@@ -487,6 +487,10 @@ classdef ListSelector < matlab.ui.componentcontainer.ComponentContainer & ...
             end
         end
         function set.HighlightedValue(obj,value)
+            if isempty(value)
+                obj.ListBox.Value = {};
+                return;
+            end
             if isempty(obj.ItemsData)
                 [~, obj.ListBox.Value] = ismember(value, obj.Items);
             else

--- a/widgets/+wt/ListSelectorTwoPane.m
+++ b/widgets/+wt/ListSelectorTwoPane.m
@@ -546,6 +546,7 @@ classdef ListSelectorTwoPane < matlab.ui.componentcontainer.ComponentContainer &
         end        
         function set.HighlightedValue(obj,value)
             if isempty(value)
+                obj.RightList.Value = {};
                 return;
             end
             if isempty(obj.ItemsData)


### PR DESCRIPTION
This change includes the following:

For ListSelectorTwoPane and ListSelector:
- Allows for deselection of HighlightedValue in ListSelectorTwoPane which was previously not possible due to a change because of issue #57. Please test if the current change does not re-introduce issue #57. 

For BaseApp:
- Fixes issue #68 
- Uses arguments block for input parsing
- Uses isprop(obj.Figure, "Position") instead of isvalid(obj.Figure). If a user deletes the figure instead of the app, the delete method of the app will still be triggered. Although not yet fully deleted (property values are still available), the app and figure will not be valid at this point. 