### PR TITLE
Add test for Project integrity checks and fix adding a few files

### DIFF
--- a/resources/project/LwJcy9ZaEyJvuNK-ApM3PZoS5oo/zElVE5iTAf8BJd9MCDX_B5ptDqYd.xml
+++ b/resources/project/LwJcy9ZaEyJvuNK-ApM3PZoS5oo/zElVE5iTAf8BJd9MCDX_B5ptDqYd.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design"/>
+    </Category>
+</Info>

--- a/resources/project/LwJcy9ZaEyJvuNK-ApM3PZoS5oo/zElVE5iTAf8BJd9MCDX_B5ptDqYp.xml
+++ b/resources/project/LwJcy9ZaEyJvuNK-ApM3PZoS5oo/zElVE5iTAf8BJd9MCDX_B5ptDqYp.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Info location="convertEnumToValue.m" type="File"/>

--- a/resources/project/Xc4-tOl6vkwzCeVKSWRahPrXJiQ/zO-r-Rt9Pem0N-xB0fa4_uvKHT0d.xml
+++ b/resources/project/Xc4-tOl6vkwzCeVKSWRahPrXJiQ/zO-r-Rt9Pem0N-xB0fa4_uvKHT0d.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="test"/>
+    </Category>
+</Info>

--- a/resources/project/Xc4-tOl6vkwzCeVKSWRahPrXJiQ/zO-r-Rt9Pem0N-xB0fa4_uvKHT0p.xml
+++ b/resources/project/Xc4-tOl6vkwzCeVKSWRahPrXJiQ/zO-r-Rt9Pem0N-xB0fa4_uvKHT0p.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Info location="ProjectIntegrityChecks.m" type="File"/>

--- a/resources/project/gdDuiZdBOBh_KnGn-recV21_YgU/IsvMQhq81RQFjLgY0WjRsMv6VCsd.xml
+++ b/resources/project/gdDuiZdBOBh_KnGn-recV21_YgU/IsvMQhq81RQFjLgY0WjRsMv6VCsd.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design"/>
+    </Category>
+</Info>

--- a/resources/project/gdDuiZdBOBh_KnGn-recV21_YgU/IsvMQhq81RQFjLgY0WjRsMv6VCsp.xml
+++ b/resources/project/gdDuiZdBOBh_KnGn-recV21_YgU/IsvMQhq81RQFjLgY0WjRsMv6VCsp.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Info location="FontWeightState.m" type="File"/>

--- a/resources/project/gdDuiZdBOBh_KnGn-recV21_YgU/KNcod6hqT3D6WvGpK-7EgBsWwpMd.xml
+++ b/resources/project/gdDuiZdBOBh_KnGn-recV21_YgU/KNcod6hqT3D6WvGpK-7EgBsWwpMd.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Info>
+    <Category UUID="FileClassCategory">
+        <Label UUID="design"/>
+    </Category>
+</Info>

--- a/resources/project/gdDuiZdBOBh_KnGn-recV21_YgU/KNcod6hqT3D6WvGpK-7EgBsWwpMp.xml
+++ b/resources/project/gdDuiZdBOBh_KnGn-recV21_YgU/KNcod6hqT3D6WvGpK-7EgBsWwpMp.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Info location="FontAngleState.m" type="File"/>

--- a/test/+wt/+test/ProjectIntegrityChecks.m
+++ b/test/+wt/+test/ProjectIntegrityChecks.m
@@ -16,11 +16,15 @@ classdef ProjectIntegrityChecks < matlab.unittest.TestCase
 
             proj = currentProject();
 
+            updateDependencies(proj);
             checkResults = runChecks(proj);
 
             % Verify checks with useful diagnostic
             for idx = 1:length(checkResults)
-                diagnostic = "Failed Integrity Test: '" + checkResults(idx).Description + "'" + newline + "Problem files:" + newline + sprintf("%s\n", checkResults(idx).ProblemFiles);
+                diagnostic = "Failed Integrity Test: '" + checkResults(idx).Description + "'";
+                if ~isempty(checkResults(idx).ProblemFiles)
+                    diagnostic = diagnostic + newline + "Problem file(s):" + newline + sprintf("- %s\n", checkResults(idx).ProblemFiles);
+                end
                 testCase.verifyTrue(checkResults(idx).Passed, diagnostic);
             end
 

--- a/test/+wt/+test/ProjectIntegrityChecks.m
+++ b/test/+wt/+test/ProjectIntegrityChecks.m
@@ -1,0 +1,30 @@
+classdef ProjectIntegrityChecks < matlab.unittest.TestCase
+    % Implements a unit test that runs the Project Integrity Checks
+
+    properties(Access = private)
+        DoNotRun = verLessThan("MATLAB", "9.9"); %#ok<VERLESSMATLAB> to support running this in < R2020b
+    end
+
+    methods(Test)
+        function runProjectChecks(testCase)
+            % do not continue if DoNotRun is set
+            testCase.assumeFalse(testCase.DoNotRun, "Integrity Checks can only be run on R2020b or newer programmatically.")
+
+            % find project root folder based on this file (3 folders up)
+            prjFolder = fileparts(fileparts(fileparts(fileparts(mfilename("fullpath")))));
+            testCase.applyFixture(matlab.unittest.fixtures.ProjectFixture(prjFolder))
+
+            proj = currentProject();
+
+            checkResults = runChecks(proj);
+
+            % Verify checks with useful diagnostic
+            for idx = 1:length(checkResults)
+                diagnostic = "Failed Integrity Test: '" + checkResults(idx).Description + "'" + newline + "Problem files:" + newline + sprintf("%s\n", checkResults(idx).ProblemFiles);
+                testCase.verifyTrue(checkResults(idx).Passed, diagnostic);
+            end
+
+        end
+    end
+
+end


### PR DESCRIPTION
This is related to #88, while the reported file in that issue is no longer in the repo, there are 3 other files in the repo which are missing in the Project. I thought maybe useful to include a test class, such that you get notified of this "issue" every time the test suite is run?