### PR TITLE
Introduces ButtonHeight

### DIFF
--- a/test/+wt/+test/ButtonGrid.m
+++ b/test/+wt/+test/ButtonGrid.m
@@ -190,6 +190,44 @@ classdef ButtonGrid < wt.test.BaseWidgetTest
             testCase.verifyMatches(button.IconAlignment, newValue);
             
         end %function
+
+
+        function testButtonWidthHeight(testCase)
+            
+            % Default size
+            testCase.verifySetProperty("DefaultSize", 20, "20");
+            testCase.verifySetProperty("DefaultSize", 'fit', "fit");
+            testCase.verifySetProperty("DefaultSize", '2x', "2x");
+
+            % Horizontal layout
+            testCase.verifySetProperty("ButtonWidth", "fit", {'fit' 'fit'})
+            testCase.verifySetProperty("ButtonWidth", {10 'fit'}, {10 'fit'})
+            testCase.verifySetProperty("ButtonWidth", [10 20 30 40], {10 20})
+
+            testCase.verifySetProperty("ButtonHeight", {10 'fit'}, {10})
+            testCase.verifySetProperty("ButtonHeight", 20, {20})
+
+            % Additional buttons
+            testCase.verifySetProperty("DefaultSize", 30, "30");
+            testCase.verifySetProperty("Text", ["1", "2", "3", "4"], ["1", "2", "3", "4"])
+            testCase.verifyEqual(testCase.Widget.ButtonWidth, {10 20 30 30})
+
+            % Change to vertical layout
+            newOrientation = "vertical";
+            testCase.verifySetProperty("Orientation", newOrientation);
+
+            % Vertical layout
+            testCase.verifySetProperty("ButtonHeight", 30, {30 30 30 30})
+            testCase.verifySetProperty("ButtonHeight", "fit", {'fit' 'fit' 'fit' 'fit'})
+            testCase.verifySetProperty("ButtonHeight", [10 20], {10 20 'fit' 'fit'})
+            testCase.verifySetProperty("ButtonHeight", {10 'fit'}, {10 'fit' 'fit' 'fit'})
+
+            testCase.verifySetProperty("ButtonHeight", [10 20 30 40 50], {10 20 30 40})
+
+            testCase.verifySetProperty("ButtonWidth", {10 'fit'}, {10})
+            testCase.verifySetProperty("ButtonWidth", 20, {20})
+            
+        end
         
     end %methods (Test)
     

--- a/test/+wt/+test/ListSelector.m
+++ b/test/+wt/+test/ListSelector.m
@@ -315,6 +315,40 @@ classdef ListSelector < wt.test.BaseWidgetTest
         
         
         
+        function testSortable(testCase)
+
+            % Get the listbox and button grid
+            w = testCase.Widget;
+            listControl = testCase.Widget.ListBox;
+            buttonGrid = testCase.Widget.ListButtons;
+            button = buttonGrid.Button;
+            
+            % Add a list of items and put all on list
+            testCase.verifySetProperty("Value", testCase.ItemNames);
+
+            % Select multiple items with mouse
+            selIdx = [2 3];
+            testCase.choose(listControl, selIdx)
+
+            % Move items further down
+            testCase.press(button(4))
+            testCase.press(button(4))
+
+            % Press down one too many
+            testCase.press(button(4))
+
+            % Switch Sortable option off
+            testCase.verifySetProperty("Sortable", false);
+            testCase.verifyEquality(w.SelectedIndex, 1:numel(testCase.ItemNames));
+            
+            % Switch Sortable option back on
+            testCase.verifySetProperty("Sortable", true);
+            testCase.verifyEquality(w.SelectedIndex, 1:numel(testCase.ItemNames));
+
+        end
+
+
+
         function testUserButtons(testCase)
             
             % Get the widget

--- a/widgets/+wt/ButtonGrid.m
+++ b/widgets/+wt/ButtonGrid.m
@@ -42,9 +42,6 @@ classdef ButtonGrid < wt.abstract.BaseWidget & ...
         % Alignment of the icon
         IconAlignment (1,1) wt.enum.AlignmentState = wt.enum.AlignmentState.top
 
-        % Default size of new buttons ('1x' or 'fit')
-        DefaultSize {mustBeMember(DefaultSize,{'1x','fit'})} = '1x'
-
     end %properties
 
 
@@ -158,15 +155,6 @@ classdef ButtonGrid < wt.abstract.BaseWidget & ...
                 end %if obj.Orientation == "vertical"
 
             end %for idx = 1:numNew
-
-            % Update layout
-            if obj.Orientation == "vertical"
-                obj.Grid.ColumnWidth = {obj.DefaultSize};
-                obj.Grid.RowHeight = repmat({obj.DefaultSize},1,numNew);
-            else
-                obj.Grid.ColumnWidth = repmat({obj.DefaultSize},1,numNew);
-                obj.Grid.RowHeight = {obj.DefaultSize};
-            end %if obj.Orientation == "vertical"
 
         end %function
 

--- a/widgets/+wt/ButtonGrid.m
+++ b/widgets/+wt/ButtonGrid.m
@@ -180,6 +180,18 @@ classdef ButtonGrid < wt.abstract.BaseWidget & ...
 
         end %function
 
+        function updateGridForButton(obj, prop, value)
+            % Update main grid properties to value
+
+            % If value is a scalar, repeat it for every button.
+            if isscalar(value)
+                nCells = numel(obj.Grid.(prop));
+                value = repmat(value, 1, nCells);
+            end
+            obj.Grid.(prop) = value;
+            
+        end %function
+
     end %methods
 
 
@@ -191,14 +203,14 @@ classdef ButtonGrid < wt.abstract.BaseWidget & ...
             value = obj.Grid.ColumnWidth;
         end
         function set.ButtonWidth(obj,value)
-            obj.Grid.ColumnWidth = value;
+            obj.updateGridForButton("ColumnWidth", value);
         end
 
         function value = get.ButtonHeight(obj)
             value = obj.Grid.RowHeight;
         end
         function set.ButtonHeight(obj,value)
-            obj.Grid.RowHeight = value;
+            obj.updateGridForButton("RowHeight", value);
         end
 
     end %methods

--- a/widgets/+wt/ListSelector.m
+++ b/widgets/+wt/ListSelector.m
@@ -439,12 +439,18 @@ classdef ListSelector < wt.abstract.BaseWidget & ...
         function promptToAddListItems(obj)
             % Prompt a dialog to add items to the listbox
 
+            % Take ItemsData into account while displaying Items
+            items = obj.Items;
+            if ~isempty(obj.ItemsData)
+                items = items(1:min(numel(items), numel(obj.ItemsData)));
+            end
+
             % Prompt for stuff to add
             if obj.AllowDuplicates
-                newSelIdx = listdlg("ListString",obj.Items);
+                newSelIdx = listdlg("ListString",items);
             else
                 newSelIdx = listdlg(...
-                    "ListString",obj.Items,...
+                    "ListString",items,...
                     "InitialValue",obj.ListBox.ItemsData);
             end
 

--- a/widgets/+wt/ListSelector.m
+++ b/widgets/+wt/ListSelector.m
@@ -35,6 +35,9 @@ classdef ListSelector < wt.abstract.BaseWidget & ...
         % Indicates whether to allow duplicate entries in the list
         AllowDuplicates  (1,1) matlab.lang.OnOffSwitchState = false
 
+         % Indicates whether to allow sort controls
+        Sortable  (1,1) matlab.lang.OnOffSwitchState = true
+
         % Inidicates what to do when add button is pressed (select from
         % Items or custom using ButtonPushed event or ButtonPushedFcn)
         AddSource (1,1) wt.enum.ListAddSource = wt.enum.ListAddSource.Items
@@ -104,9 +107,18 @@ classdef ListSelector < wt.abstract.BaseWidget & ...
 
         function value = get.ValueIndex(obj)
             value = obj.ListBox.ItemsData;
+            value(value > obj.getMaximumValidItemsNumber) = [];
         end
 
         function set.ValueIndex(obj,value)
+            if any(value > numel(obj.Items))
+                error("widgets:ListSelector:ValueIndex",...
+                        "'ValueIndex' must be within the length of the 'Items' property.")
+            end
+            if ~isempty(obj.ItemsData) && any(value > numel(obj.ItemsData))
+                error("widgets:ListSelector:ValueIndex",...
+                        "'ValueIndex' must be within the length of the 'ItemsData' property.")
+            end
             obj.ListBox.Items = obj.Items(value);
             obj.ListBox.ItemsData = value;
         end
@@ -123,7 +135,7 @@ classdef ListSelector < wt.abstract.BaseWidget & ...
 
         function set.Value(obj,value)
             if isempty(value)
-                obj.SelectedIndex = [];
+                obj.ValueIndex = [];
             else
                 if isempty(obj.ItemsData)
                     [tf, selIdx] = ismember(value, obj.Items);
@@ -131,11 +143,19 @@ classdef ListSelector < wt.abstract.BaseWidget & ...
                     [tf, selIdx] = ismember(value, obj.ItemsData);
                 end
                 if ~all(tf)
-                    warning("widgets:ListSelector:InvalidValue",...
-                        "Attempt to set an invalid Value to the list.")
-                    selIdx(~tf) = [];
+                    if isempty(obj.ItemsData)
+                        itemValueName = 'Items';
+                    else
+                        itemValueName = 'ItemsData';
+                    end
+                    error("widgets:ListSelector:InvalidValue",...
+                        "'Value' must be an element defined in the '%s' property.", itemValueName)
                 end
-                obj.SelectedIndex = selIdx;
+                if ~isempty(obj.ItemsData) && numel(tf) > numel(obj.Items)
+                    error("widgets:ListSelector:InvalidValue",...
+                        "'Value' must be an element defined in the 'ItemsData' property within the length of the 'Items' property.")
+                end
+                obj.ValueIndex = selIdx;
             end
         end
 
@@ -289,7 +309,17 @@ classdef ListSelector < wt.abstract.BaseWidget & ...
         function update(obj)
 
             % What is selected?
-            selIdx = obj.SelectedIndex;
+            selIdx = obj.ValueIndex;
+
+            % Is the list sortable?
+            if obj.Sortable
+                obj.ListButtons.Icon = ["add_24.png", "delete_24.png", "up_24.png", "down_24.png"];
+                obj.ListButtons.ButtonTag = ["Add", "Remove", "Up", "Down"];
+            else
+                selIdx = sort(selIdx);
+                obj.ListButtons.Icon = ["add_24.png", "delete_24.png"];
+                obj.ListButtons.ButtonTag = ["Add", "Remove"];
+            end
 
             % Update the list
             obj.ListBox.Items = obj.Items(selIdx);
@@ -313,7 +343,7 @@ classdef ListSelector < wt.abstract.BaseWidget & ...
             if obj.Enable
 
                 % What is selected?
-                selIdx = obj.SelectedIndex;
+                selIdx = obj.ValueIndex;
                 numRows = numel(selIdx);
 
                 % Highlighted selection in list?
@@ -418,21 +448,27 @@ classdef ListSelector < wt.abstract.BaseWidget & ...
                     "InitialValue",obj.ListBox.ItemsData);
             end
 
+            % Restore figure focus
+            fig = ancestor(obj,"figure");
+            if isscalar(fig) && isvalid(fig)
+                figure(fig)
+            end
+            
             if isempty(newSelIdx)
                 % User cancelled
                 return
             elseif obj.AllowDuplicates
-                newSelIdx = [obj.SelectedIndex newSelIdx];
+                newSelIdx = [obj.ValueIndex newSelIdx];
             end
 
             % Was a change made?
-            if ~isequal(obj.SelectedIndex, newSelIdx)
+            if ~isequal(obj.ValueIndex, newSelIdx)
 
                 % Get the original value
                 oldValue = obj.Value;
 
                 % Make the update
-                obj.SelectedIndex = newSelIdx;
+                obj.ValueIndex = newSelIdx;
 
                 % Trigger event
                 evtOut = wt.eventdata.ValueChangedData(obj.Value, oldValue);
@@ -512,6 +548,19 @@ classdef ListSelector < wt.abstract.BaseWidget & ...
 
             % Update buttons
             obj.updateEnables()
+
+        end %function
+
+        function val = getMaximumValidItemsNumber(obj)
+            % Returns maximum valid selected index.
+            % Takes into account ItemsData and Items.
+
+            % Is ItemsData available?
+            if ~isempty(obj.ItemsData)
+                val = min(numel(obj.ItemsData), numel(obj.Items));
+            else
+                val = numel(obj.Items);
+            end
 
         end %function
 

--- a/widgets/+wt/ListSelector.m
+++ b/widgets/+wt/ListSelector.m
@@ -39,6 +39,12 @@ classdef ListSelector < wt.abstract.BaseWidget & ...
         % Items or custom using ButtonPushed event or ButtonPushedFcn)
         AddSource (1,1) wt.enum.ListAddSource = wt.enum.ListAddSource.Items
 
+         % Width of the buttons
+        ButtonWidth = 25
+
+        % Height of the buttons
+        ButtonHeight = 25
+
     end %properties
 
     methods
@@ -90,14 +96,6 @@ classdef ListSelector < wt.abstract.BaseWidget & ...
 
         % The current highlighted selection
         HighlightedValue (1,:)
-
-    end %properties
-
-
-    properties (AbortSet, Dependent, UsedInUpdate = false)
-
-        % Width of the buttons
-        ButtonWidth
 
     end %properties
 
@@ -164,15 +162,6 @@ classdef ListSelector < wt.abstract.BaseWidget & ...
             else
                 [~, obj.ListBox.Value] = ismember(value, obj.ItemsData);
             end
-        end
-
-
-        function value = get.ButtonWidth(obj)
-            value = obj.Grid.ColumnWidth{2};
-        end
-
-        function set.ButtonWidth(obj,value)
-            obj.Grid.ColumnWidth{2} = value;
         end
 
     end %methods
@@ -257,8 +246,8 @@ classdef ListSelector < wt.abstract.BaseWidget & ...
 
             % Configure grid
             obj.Grid.Padding = 3;
-            obj.Grid.ColumnWidth = {'1x',25};
-            obj.Grid.RowHeight = {106,'1x'};
+            obj.Grid.ColumnWidth = {'1x','fit'};
+            obj.Grid.RowHeight = {'fit','1x'};
 
             % Create the list buttons
             obj.ListButtons = wt.ButtonGrid(obj.Grid);
@@ -305,6 +294,12 @@ classdef ListSelector < wt.abstract.BaseWidget & ...
             % Update the list
             obj.ListBox.Items = obj.Items(selIdx);
             obj.ListBox.ItemsData = selIdx;
+
+            % Button width and height
+            obj.UserButtons.ButtonWidth = obj.ButtonWidth;
+            obj.ListButtons.ButtonWidth = obj.ButtonWidth;
+            obj.UserButtons.ButtonHeight = obj.ButtonHeight;
+            obj.ListButtons.ButtonHeight = obj.ButtonHeight;
 
             % Update button enable states
             obj.updateEnables();

--- a/widgets/+wt/ListSelectorTwoPane.m
+++ b/widgets/+wt/ListSelectorTwoPane.m
@@ -35,6 +35,12 @@ classdef ListSelectorTwoPane < wt.abstract.BaseWidget & ...
         % Indicates whether to allow sort controls
         Sortable (1,1) matlab.lang.OnOffSwitchState = true
 
+        % Width of the buttons
+        ButtonWidth = 25
+
+        % Height of the buttons
+        ButtonHeight = 25
+
     end %properties
 
 
@@ -62,14 +68,6 @@ classdef ListSelectorTwoPane < wt.abstract.BaseWidget & ...
 
         % Indices of the highlighted items on left
         HighlightedIndexLeft
-
-    end %properties
-
-
-    properties (AbortSet, Dependent, UsedInUpdate = false)
-
-        % Width of the buttons
-        ButtonWidth
 
     end %properties
 
@@ -117,14 +115,14 @@ classdef ListSelectorTwoPane < wt.abstract.BaseWidget & ...
 
             % Configure grid
             obj.Grid.Padding = 3;
-            obj.Grid.ColumnWidth = {'1x',28,'1x'};
-            obj.Grid.RowHeight = {'fit','1x'};
+            obj.Grid.ColumnWidth = {'1x','fit','1x'};
+            obj.Grid.RowHeight = {'fit','fit','1x'};
 
             % Create the left Listbox
             obj.LeftList = uilistbox(obj.Grid);
             obj.LeftList.Multiselect = true;
             obj.LeftList.Layout.Column = 1;
-            obj.LeftList.Layout.Row = [1 2];
+            obj.LeftList.Layout.Row = [1 3];
             obj.LeftList.ValueChangedFcn = @(h,e)obj.onLeftSelectionChanged(e);
 
             % Create the list buttons
@@ -143,7 +141,7 @@ classdef ListSelectorTwoPane < wt.abstract.BaseWidget & ...
             obj.RightList = uilistbox(obj.Grid);
             obj.RightList.Multiselect = true;
             obj.RightList.Layout.Column = 3;
-            obj.RightList.Layout.Row = [1 2];
+            obj.RightList.Layout.Row = [1 3];
             obj.RightList.ValueChangedFcn = @(h,e)obj.onRightSelectionChanged(e);
 
             % Update listeners
@@ -187,12 +185,16 @@ classdef ListSelectorTwoPane < wt.abstract.BaseWidget & ...
             if obj.Sortable
                 obj.ListButtons.Icon = ["right_24.png", "left_24.png", "up_24.png", "down_24.png"];
                 obj.ListButtons.ButtonTag = ["Add", "Remove", "Up", "Down"];
-                obj.ListButtons.ButtonHeight = {28 28 28 28};
             else
                 obj.ListButtons.Icon = ["right_24.png", "left_24.png"];
                 obj.ListButtons.ButtonTag = ["Add", "Remove"];
-                obj.ListButtons.ButtonHeight = {28 28};
             end
+
+            % Button width and height
+            obj.UserButtons.ButtonWidth = obj.ButtonWidth;
+            obj.ListButtons.ButtonWidth = obj.ButtonWidth;
+            obj.UserButtons.ButtonHeight = obj.ButtonHeight;
+            obj.ListButtons.ButtonHeight = obj.ButtonHeight;
 
             % Update button enable states
             obj.updateEnables();
@@ -592,13 +594,6 @@ classdef ListSelectorTwoPane < wt.abstract.BaseWidget & ...
             if isempty(value)
                 value = [];
             end
-        end
-
-        function value = get.ButtonWidth(obj)
-            value = obj.Grid.ColumnWidth{2};
-        end
-        function set.ButtonWidth(obj,value)
-            obj.Grid.ColumnWidth{2} = value;
         end
 
     end %methods


### PR DESCRIPTION
Introduces ButtonHeight for ButtonGrid, ListSelector and ListSelectorTwoPane. 

In **ButtonGrid** widget:
Fixes #129 by setting ButtonWidth and ButtonHeight grids only for newly created buttons.
Allows DefaultSize to be a (string) absolute or relative number besides the key-words "fit" and "1x".

In **ListSelector**:
Adds a Sortable option for ListSelector. 
Takes ItemsData into account while setting ValueIndex and showing AddList in ListSelector.
Replaces SelectedIndex by ValueIndex in ListSelector class definition. Keeps SelectedIndex for backward compatibility.

I ran the test suite in MATLAB 2022b and is passes. 