### PR TITLE
Recreate event object for ListSelector

### DIFF
--- a/test/+wt/+test/ListSelector.m
+++ b/test/+wt/+test/ListSelector.m
@@ -39,6 +39,11 @@ classdef ListSelector < wt.test.BaseWidgetTest
             
             % Set the initial items
             testCase.verifySetProperty("Items", testCase.ItemNames);
+
+            % Set callback
+            testCase.Widget.ButtonPushedFcn = @(s,e)onCallbackTriggered(testCase,e);
+            testCase.Widget.ValueChangedFcn = @(s,e)onCallbackTriggered(testCase,e);
+            testCase.Widget.HighlightedValueChangedFcn = @(s,e)onCallbackTriggered(testCase,e);
             
         end %function
         
@@ -363,6 +368,29 @@ classdef ListSelector < wt.test.BaseWidgetTest
             testCase.verifyNumElements(b, 2);
             testCase.press(b(1))
             testCase.press(b(2))
+
+            % Verify callbacks fired
+            testCase.verifyEqual(testCase.CallbackCount, 2);
+            
+        end %function
+
+
+
+        function testAddSource(testCase)
+            
+            % Get the widget
+            w = testCase.Widget;
+            buttonGrid = testCase.Widget.ListButtons;
+            button = buttonGrid.Button;
+
+            % Add User buttons
+            w.AddSource = 'ButtonPushedFcn';
+            
+            % Press the buttons
+            testCase.press(button(1))
+
+            % Verify callbacks fired
+            testCase.verifyEqual(testCase.CallbackCount, 1);
             
         end %function
         

--- a/widgets/+wt/ListSelector.m
+++ b/widgets/+wt/ListSelector.m
@@ -411,7 +411,9 @@ classdef ListSelector < wt.abstract.BaseWidget & ...
                             obj.promptToAddListItems()
 
                         case wt.enum.ListAddSource.ButtonPushedFcn
-                            notify(obj,"ButtonPushed",evt);
+                            % Trigger event for user buttons
+                            evtOut = wt.eventdata.ButtonPushedData(evt.Button);
+                            notify(obj,"ButtonPushed",evtOut);
 
                     end %switch obj.AddSource
 
@@ -426,7 +428,8 @@ classdef ListSelector < wt.abstract.BaseWidget & ...
 
                 otherwise
                     % Trigger event for user buttons
-                    notify(obj,"ButtonPushed",evt);
+                    evtOut = wt.eventdata.ButtonPushedData(evt.Button);
+                    notify(obj,"ButtonPushed",evtOut);
 
             end %switch
 


### PR DESCRIPTION
These changes fix issue #136 and extend the testcases to include the AddSource functionality.

I ran the test suite in MATLAB R2022b. All seems OK. 