### PR TITLE
Focusable PasswordField and ButtonLabel for FileSelector

### DIFF
--- a/test/+wt/+test/FileSelector.m
+++ b/test/+wt/+test/FileSelector.m
@@ -166,6 +166,24 @@ classdef FileSelector < wt.test.BaseWidgetTest
             
         end %function
         
+        function testButtonLabel(testCase)
+            
+            % Get the edit field
+            buttonControl = testCase.Widget.ButtonControl;
+            
+            % Set the value
+            newValue = "Select File";
+            testCase.verifySetProperty("ButtonLabel", newValue);
+            drawnow
+            testCase.verifyEqual(string(buttonControl.Text), newValue);
+            
+            % Set the value
+            newValue = "Browse";
+            testCase.verifySetProperty("ButtonLabel", newValue);
+            drawnow
+            testCase.verifyEqual(string(buttonControl.Text), newValue);
+            
+        end %function
         
         % function testButton(testCase)
         %

--- a/test/+wt/+test/FileSelector.m
+++ b/test/+wt/+test/FileSelector.m
@@ -168,7 +168,7 @@ classdef FileSelector < wt.test.BaseWidgetTest
         
         function testButtonLabel(testCase)
             
-            % Get the edit field
+            % Get the button control
             buttonControl = testCase.Widget.ButtonControl;
             
             % Set the value
@@ -185,13 +185,75 @@ classdef FileSelector < wt.test.BaseWidgetTest
             
         end %function
         
-        % function testButton(testCase)
-        %
-        %     % We can't test the button in this case because it triggers a
-        %     % modal dialog with no way to click on the dialog.
-        %
-        % end %function
+        % Since this test-case unlocks the test figure it should be last in 
+        % line.
+        function testButton(testCase)
+        
+            % Get the button control
+            buttonControl = testCase.Widget.ButtonControl;
+
+            % Ancestor figure
+            fig = ancestor(buttonControl, "Figure");
+
+            % Make sure file dialog window is in-app by setting the
+            % 'ShowInWebApps' value to true.
+            
+            % Get active value to restore
+            s = settings;
+            curTempVal = s.matlab.ui.dialog.fileIO.ShowInWebApps.ActiveValue;
+
+            % Set temporary value of ShowInWebApps setting to true, so that file
+            % selector dialog window is a component in the figure.
+            s.matlab.ui.dialog.fileIO.ShowInWebApps.TemporaryValue = true;
+            cleanup = onCleanup(@() localRevertShowInWebAppsSetting(s, curTempVal));
+
+            % While dialog window is open and blocked by waitfor, there is still
+            % a possibility to execute code through the timer function.
+
+            % Set timer callback
+            delay = 2; % seconds
+            t = timer;
+            t.StartDelay = delay; % starts after 2 seconds
+            t.TimerFcn = @(s,e) localPressEscape(fig);
+            start(t); % start the timer
+
+            % Now press the button
+            tStart = tic;
+            testCase.press(buttonControl);
+
+            % Wait for escape button to be pressed.
+            tStop = toc(tStart);
+            
+            % Time while MATLAB waits for an action should be larger than the 
+            % StartDelay. If not, MATLAB did not reach the waitfor status after 
+            % pressing the file-selection button.
+            testCase.verifyGreaterThan(tStop, delay)            
+        
+        end %function
         
     end %methods (Test)
     
 end %classdef
+
+function localPressEscape(fig)
+
+% Unlock the figure, otherwise escape will not work.
+matlab.uitest.unlock(fig);
+
+% Bring focus to figure
+figure(fig)
+
+% Press ESCAPE
+r = java.awt.Robot;
+r.keyPress(java.awt.event.KeyEvent.VK_ESCAPE);
+pause(0.1);
+r.keyRelease(java.awt.event.KeyEvent.VK_ESCAPE);
+
+end
+
+function localRevertShowInWebAppsSetting(s, val)
+
+% Revert setting on cleanup
+s.matlab.ui.dialog.fileIO.ShowInWebApps.TemporaryValue = val;
+
+end

--- a/test/+wt/+test/PasswordField.m
+++ b/test/+wt/+test/PasswordField.m
@@ -34,33 +34,81 @@ classdef PasswordField < wt.test.BaseWidgetTest
             % Change the value programmatically
             newValue = "AbC435!";
             testCase.verifySetProperty("Value", newValue);
-            testCase.verifyMatches(passField.Data, newValue);
-            
-            
-            %testCase.verifyTypeAction(passField, newValue, "Value");
-            % Verify callback triggered
-            %testCase.verifyEqual(testCase.CallbackCount, 1)
+            testCase.verifyMatches(passField.Data.Value, newValue);
             
         end %function
         
         
-        %RAJ - Unfortunately, can't type in a uihtml
         
-        % function testTyping(testCase)
-        %
-        %     % Get the password field
-        %     passField = testCase.Widget.PasswordControl;
-        %
-        %     % Type a new value
-        %     newValue = "PasswordABC123";
-        %     testCase.verifyTypeAction(passField, newValue, "Value");
-        %     testCase.verifyMatches(passField.Data, newValue);
-        %
-        %     % Verify callback triggered
-        %     testCase.verifyEqual(testCase.CallbackCount, 1)
-        %
-        % end %function
+        function testTyping(testCase)
+        
+            % Get the password field
+            passField = testCase.Widget.PasswordControl;
+            newValue = "AbC435!";
+            testCase.verifySetProperty("Value", newValue);
+
+            % Allow for some time for the widget and HTML code to catch up
+            pause(.5)
+            focus(testCase.Widget)
+            pause(.5)
+
+            % Type a new value
+            newValue = "PasswordABC123";
+            simulateTyping(newValue);
+            simulateTyping('ENTER')
+
+            % Allow for some time for the widget to catch up
+            pause(.5)
+            testCase.verifyMatches(passField.Data.Value, newValue);
+        
+            % Verify callback triggered
+            testCase.verifyEqual(testCase.CallbackCount, 1)
+        
+        end %function
         
     end %methods (Test)
     
 end %classdef
+
+function simulateTyping(S)
+% Simulate typing actions
+
+% Convert to chars
+S = convertStringsToChars(S);
+
+%Initialize the java engine 
+import java.awt.*;
+import java.awt.event.*;
+
+%Create a Robot-object to do the key-pressing
+rob = Robot;
+
+% Request to press ENTER?
+if strcmpi(S, 'enter')
+    rob.keyPress(KeyEvent.VK_ENTER); 
+    rob.keyRelease(KeyEvent.VK_ENTER); 
+    return
+end
+
+% Execute each letter/number individually
+for idx = 1:strlength(S)
+
+    % Get key event ID
+    p = ['VK_' upper(S(idx))];
+
+    % For capital letters, press SHIFT
+    if ~strcmp(lower(S(idx)), S(idx))
+        rob.keyPress(KeyEvent.VK_SHIFT); 
+    end
+
+    % Press/release key
+    rob.keyPress(KeyEvent.(p))
+    rob.keyRelease(KeyEvent.(p))
+
+    % For capital letters, release SHIFT
+    if ~strcmp(lower(S(idx)), S(idx))
+        rob.keyRelease(KeyEvent.VK_SHIFT); 
+    end
+end
+
+end

--- a/widgets/+wt/FileSelector.m
+++ b/widgets/+wt/FileSelector.m
@@ -177,6 +177,17 @@ classdef FileSelector < wt.abstract.BaseWidget & ...
             showWarn = strlength(obj.Value) && ~obj.ValueIsValidPath;
             obj.WarnImage.Visible = showWarn;
 
+            % Set tooltip
+            if showWarn
+                if obj.SelectionType == "file"
+                    obj.WarnImage.Tooltip = 'File does not exist.';
+                elseif obj.SelectionType == "putfile"
+                    obj.WarnImage.Tooltip = 'Folder for file storage does not exist.';
+                else
+                    obj.WarnImage.Tooltip = 'Folder does not exist.';
+                end
+            end
+
             % Update button appearance
             obj.ButtonControl.Text = obj.ButtonLabel;
             if strlength(obj.ButtonLabel)

--- a/widgets/+wt/FileSelector.m
+++ b/widgets/+wt/FileSelector.m
@@ -36,6 +36,9 @@ classdef FileSelector < wt.abstract.BaseWidget & ...
 
     properties (AbortSet)
 
+        % Button text that appears on the button
+        ButtonLabel (1,1) string = ""
+
         % Selection type: (get)file, folder, putfile
         SelectionType (1,1) wt.enum.FileFolderState = wt.enum.FileFolderState.file
 
@@ -173,6 +176,14 @@ classdef FileSelector < wt.abstract.BaseWidget & ...
             % Show the warning icon?
             showWarn = strlength(obj.Value) && ~obj.ValueIsValidPath;
             obj.WarnImage.Visible = showWarn;
+
+            % Update button appearance
+            obj.ButtonControl.Text = obj.ButtonLabel;
+            if strlength(obj.ButtonLabel)
+                obj.Grid.ColumnWidth{4} = 125;
+            else
+                obj.Grid.ColumnWidth{4} = 25;
+            end
 
         end %function
 

--- a/widgets/+wt/PasswordField.m
+++ b/widgets/+wt/PasswordField.m
@@ -50,28 +50,12 @@ classdef PasswordField <  wt.abstract.BaseWidget
             obj.Position(3:4) = [100 25];
 
             % Define the HTML source
-            html = ['<input type="password" id="pass" name="password" style="width:100%;height:100%" >',...
-                '<script type="text/javascript">',...
-                'function setup(htmlComponent) {',...
-                '  htmlComponent.addEventListener("DataChanged", function(event) {',... %On uihtml Data prop changed
-                '      if (document.getElementById("pass").value !== htmlComponent.Data) {',... %Does JS value not match uihtml Data?
-                '        document.getElementById("pass").value = htmlComponent.Data;',... %Update the JS value to uihtml Data
-                '      }',...
-                '    });',...
-                '  document.getElementById("pass").addEventListener("input", function() {',...%On input to html field
-                '    htmlComponent.Data = document.getElementById("pass").value;',... %Copy JS value to uihtml data
-                '    });',...
-                '  document.addEventListener("keyup", function(event) {',... %Listen to key press
-                '      if (event.keyCode === 13) {',... %If ENTER key
-                '        htmlComponent.Data = document.getElementById("pass").value + ''\n'';',... %Add CR to data to trigger callback
-                '      }',...
-                '    });',...
-                '}',...
-                '</script>'];
+            html = HTMLComponentForPasswordField();
 
             % Create a html password input
             obj.PasswordControl = uihtml(...
                 'Parent',obj.Grid,...
+                'Data', struct('Value', "", 'DoFocus', false), ...
                 'HTMLSource',html,...
                 'DataChangedFcn',@(h,e)obj.onPasswordChanged(e) );
 
@@ -84,7 +68,7 @@ classdef PasswordField <  wt.abstract.BaseWidget
         function update(obj)
 
             % Update the edit control text
-            obj.PasswordControl.Data = obj.Value;
+            obj.PasswordControl.Data.Value = obj.Value;
 
         end %function
 
@@ -99,9 +83,9 @@ classdef PasswordField <  wt.abstract.BaseWidget
             % Triggered on interaction
 
             % Grab the data in string format
-            newValue = string(evt.Data);
+            newValue = string(evt.Data.Value);
             oldValue = obj.Value;
-            previousData = evt.PreviousData;
+            previousData = evt.PreviousData.Value;
 
             % Look at the states
             if endsWith(newValue, newline)
@@ -147,5 +131,93 @@ classdef PasswordField <  wt.abstract.BaseWidget
 
     end %methods
 
+    %% Public methods
+    methods
+
+        function focus(obj)
+
+            % Gets keyboard focus to the UI component and brings parent figure to front
+            focus(obj.PasswordControl)
+
+            % Setting 'DoFocus' to TRUE will trigger DataChanged event in HTML
+            % component, selecting the Input Field. 
+            % The HTML component reverts 'DoFocus' back to FALSE.
+            obj.PasswordControl.Data.DoFocus = true;
+
+        end %function
+
+    end %methods
+
 end % classdef
 
+function T = HTMLComponentForPasswordField()
+% Return HTML component for password field in text
+
+t = {
+    '<input type="password" id="value" style="width:100%;height:100%">                  '
+    '<script type="text/javascript">                                                '
+    '                                                                               '
+    '    function setup(htmlComponent) {                                            '
+    '                                                                               '
+    '        // Code response to data changes in MATLAB                             '
+    '        htmlComponent.addEventListener("DataChanged", dataFromMATLABToHTML);   '
+    '                                                                               '
+    '        // Update the Data property of the htmlComponent object                '
+    '        // This action also updates the Data property of the MATLAB HTML object'
+    '        // and triggers the DataChangedFcn callback function                   '
+    '        let dataInput = document.getElementById("value")                       '
+    '        dataInput.addEventListener("change", dataFromHTMLToMATLAB);            '
+    '                                                                               '
+    '        // Trigger a DataChangedFcn callback when enter is pressed.            '
+    '        document.addEventListener("keyup", onKeyPressed);                      '
+    '                                                                               '
+    '        function dataFromMATLABToHTML(event) {                                 '
+    '            let changedData = htmlComponent.Data;                              '
+    '            console.log("New data from MATLAB:", changedData);                 '
+    '                                                                               '
+    '            // Update your HTML or JavaScript with the new data                '
+    '            let domValue = document.getElementById("value");                   '
+    '            domValue.value = changedData.Value;                                '
+    '                                                                               '
+    '            // Focus on the input element                                      '
+    '            if (changedData.DoFocus){                                          '
+    '                                                                               '
+    '                // Focus on input field                                        '
+    '                domValue.focus();                                              '
+    '                domValue.select();                                             '
+    '                                                                               '
+    '                // Revert value for focus event                                '
+    '                changedData.DoFocus = false;                                   '
+    '                htmlComponent.Data = changedData;                              '
+    '            }                                                                  '
+    '        }                                                                      '
+    '                                                                               '
+    '        function dataFromHTMLToMATLAB(event) {                                 '
+    '            let newValue = event.target.value;                                 '
+    '            let newData = htmlComponent.Data;                                  '
+    '                                                                               '
+    '            newData.Value = newValue;                                          '
+    '                                                                               '
+    '            htmlComponent.Data = newData;                                      '
+    '        }                                                                      '
+    '                                                                               '
+    '        function onKeyPressed(event) {                                         '
+    '                                                                               '
+    '            // Get data to change                                              '
+    '            let newData = htmlComponent.Data;                                  '
+    '            let domValue = document.getElementById("value");                   '
+    '                                                                               '
+    '            // ENTER key?                                                      '
+    '            if (event.keyCode === 13) {                                        '
+    '                newData.Value = domValue.value + "\n";                         '
+    '                htmlComponent.Data = newData;                                  '
+    '            }                                                                  '
+    '        }                                                                      '
+    '    }                                                                          '
+    '</script>                                                                      '
+};
+
+% Join cellstr to text scalar
+t = convertCharsToStrings(t);
+T = join(t, newline);
+end

--- a/widgets/+wt/PasswordField.m
+++ b/widgets/+wt/PasswordField.m
@@ -136,13 +136,20 @@ classdef PasswordField <  wt.abstract.BaseWidget
 
         function focus(obj)
 
-            % Gets keyboard focus to the UI component and brings parent figure to front
+            % Brings parent figure to front
             focus(obj.PasswordControl)
 
-            % Setting 'DoFocus' to TRUE will trigger DataChanged event in HTML
-            % component, selecting the Input Field. 
-            % The HTML component reverts 'DoFocus' back to FALSE.
-            obj.PasswordControl.Data.DoFocus = true;
+            % What MATLAB version?
+            if ~isMATLABReleaseOlderThan("R2023a")
+                % Fire event 'FocusOnInputField' that will trigger the HTML
+                % component to select the Input Field directly.
+                sendEventToHTMLSource(obj.PasswordControl, 'FocusOnInputField', '')
+            else
+                % Setting 'DoFocus' to TRUE will trigger DataChanged event in HTML
+                % component, selecting the Input Field. 
+                % The HTML component reverts 'DoFocus' back to FALSE.
+                obj.PasswordControl.Data.DoFocus = true;
+            end
 
         end %function
 
@@ -161,6 +168,9 @@ t = {
     '                                                                               '
     '        // Code response to data changes in MATLAB                             '
     '        htmlComponent.addEventListener("DataChanged", dataFromMATLABToHTML);   '
+    '                                                                               '
+    '        // Code response to FocusOnInputField event in MATLAB                  '
+    '        htmlComponent.addEventListener("FocusOnInputField", focusInputField);  '
     '                                                                               '
     '        // Update the Data property of the htmlComponent object                '
     '        // This action also updates the Data property of the MATLAB HTML object'
@@ -189,6 +199,16 @@ t = {
     '                // Revert value for focus event                                '
     '                changedData.DoFocus = false;                                   '
     '                htmlComponent.Data = changedData;                              '
+    '            }                                                                  '
+    '        }                                                                      '
+    '                                                                               '
+    '        function focusInputField(event) {                                      '
+    '            let domValue = document.getElementById("value");                   '
+    '                                                                               '
+    '            // Focus on the input element                                      '
+    '            if (domValue) {                                                    '
+    '               domValue.focus();                                               '
+    '               domValue.select();                                              '
     '            }                                                                  '
     '        }                                                                      '
     '                                                                               '


### PR DESCRIPTION
This pull request implements the following enhancements:

**wt.PasswordField**
- Method `focus` for wt.PasswordField. For MATLAB older than R2023a, the 'DataChanged' event is used to trigger the HTML component. For newer releases, the custom 'FocusOnInputField' event is implemented.
- Test case implemented that types in the HTML component by using `java.awt.Robot`.

**wt.FileSelector**
- Property `ButtonLabel` implemented that enables the user to add a label next to the icon in the brows button.
- Testcase added for `ButtonLabel` property.
- Testcase `testButton` added that shows the file selection dialog within the figure and simulates pressing ESCAPE using `java.awt.Robot` to close the window. To circumvent MATLAB's `waitfor`  a `timer` event is used. **NOTE:** The test figure is unlocked to enable the figure to respond to this action.

@rjackey this pull request uses `java.awt.Robot` in testcases to simulate keyboard hits that could cause funny behavior if the user keeps interacting with the computer while running the testcases. I can imagine that you would not want this behavior. If so, I would be happy to remove it.