### PR TITLE
Execute keyboard tests only in desktop mode

### DIFF
--- a/test/+wt/+test/FileSelector.m
+++ b/test/+wt/+test/FileSelector.m
@@ -189,6 +189,10 @@ classdef FileSelector < wt.test.BaseWidgetTest
         % line.
         function testButton(testCase)
         
+            % Running in desktop mode?
+            testCase.assumeEqual(exist('desktop', 'file'), 6, 'Cannot find function ''desktop.m''.')
+            testCase.assumeTrue(desktop('-inuse'), 'MATLAB must run in desktop mode in order to complete current test.')
+
             % Get the button control
             buttonControl = testCase.Widget.ButtonControl;
 

--- a/test/+wt/+test/PasswordField.m
+++ b/test/+wt/+test/PasswordField.m
@@ -42,6 +42,10 @@ classdef PasswordField < wt.test.BaseWidgetTest
         
         function testTyping(testCase)
         
+            % Running in desktop mode?
+            testCase.assumeEqual(exist('desktop', 'file'), 6, 'Cannot find function ''desktop.m''.')
+            testCase.assumeTrue(desktop('-inuse'), 'MATLAB must run in desktop mode in order to complete current test.')
+            
             % Get the password field
             passField = testCase.Widget.PasswordControl;
             newValue = "AbC435!";


### PR DESCRIPTION
Execute tests that use keyboard input for **wt.PasswordField** and **wt.FileSelector** only in desktop mode.

Used function `desktop('-inuse')` to verify if MATLAB runs in desktop mode (see: [https://nl.mathworks.com/matlabcentral/answers/2051517-how-does-matlab-know-it-ran-from-vscode-or-desktop](https://nl.mathworks.com/matlabcentral/answers/2051517-how-does-matlab-know-it-ran-from-vscode-or-desktop)).

@rjackey I'm not sure if this will fix the issue of test cases not completing when executed in CI tasks (see comment in #139)